### PR TITLE
Release notes på all release

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -58,3 +58,18 @@ jobs:
         mvn --batch-mode versions:set -DnewVersion=${{ inputs.version }} -DprocessAllModules -DgenerateBackupPoms=false
         mvn ${{ inputs.goals }}
         mvn --batch-mode build-helper:parse-version versions:set -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.nextIncrementalVersion}-SNAPSHOT -DprocessAllModules -DgenerateBackupPoms=false
+    - name: Create release with release notes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        tag: ${{ github.ref_name }}
+      run: |
+        gh release create "$tag" \
+            --repo="$GITHUB_REPOSITORY" \
+            --title="${tag#v}" \
+            --generate-notes
+    - name: Only keep latest 25 releases
+      uses: dev-drprasad/delete-older-releases@v0.3.4
+      with:
+        keep_latest: 25
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Siden vi nå innfører PR på alle repository i NKK, så kan vi like greit innføre auto release notes på alle releaser også.

Denne PR oppdaterer felles release workflow slik at den genererer en release med notes. Dette er kopiert fra nkk-eierskifte-24. Det er også lagt inn automatisk sletting av releases hvor vi beholder de 25 siste, dette er for å begrense bruk av storage på GitHub.

Hvis vi merger denne, så må vi i samme omgang fjerne release notes generering fra nkk-eierskifte-24 slik at den ikke feiler.