### PR TITLE
chore: add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/deploy-jetty-ec2.yml
+++ b/.github/workflows/deploy-jetty-ec2.yml
@@ -25,6 +25,10 @@ on:
         type: string
         default: 'clean package'
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-jetty.yml
+++ b/.github/workflows/deploy-jetty.yml
@@ -22,6 +22,9 @@ on:
         type: string
         default: 'clean package'
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: self-hosted

--- a/.github/workflows/deploy-spring-boot.yml
+++ b/.github/workflows/deploy-spring-boot.yml
@@ -25,6 +25,10 @@ on:
         type: string
         default: 'jetty:jetty'
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -13,6 +13,10 @@ on:
       PACKAGES_TOKEN:
         required: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -16,6 +16,10 @@ on:
         type: number
         default: 17
         
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   build:
 


### PR DESCRIPTION
# Pull Request

## Description

Add explicit `permissions:` blocks to all GitHub Actions workflow files to satisfy the "Workflow does not contain permissions" security rule from GitHub code scanning.

Without explicit permissions, `GITHUB_TOKEN` defaults to broad read/write access on all scopes. Each workflow now declares only the permissions it actually needs:
- `contents: write` + `packages: write` — release workflows (create releases, publish packages)
- `contents: write` — package/release cleaner workflows (delete releases)
- `packages: write` — package version cleaner workflows (delete package versions)
- `contents: read` + `packages: read` — build, deploy, and pull request workflows
- `contents: read` — workflows with no package registry access needed

No functional changes — only token scope restrictions.

## How Has This Been Tested?

- [ ] I confirm that I have reproduced the initial situation
- [ ] I confirm that I have tested my implementation and it is working as expected

### Where was this tested?

- [ ] Localhost
- [ ] Inttest
- [ ] Prodtest
- [ ] Production

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules