### PR TITLE
chore: auto-merge grouped dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,7 +18,8 @@ jobs:
         if: >-
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.package-ecosystem == 'github_actions' ||
-          contains(steps.meta.outputs.dependency-names, 'no.nkk')
+          contains(steps.meta.outputs.dependency-names, 'no.nkk') ||
+          steps.meta.outputs.dependency-group != ''
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -28,7 +29,8 @@ jobs:
         if: >-
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.package-ecosystem == 'github_actions' ||
-          contains(steps.meta.outputs.dependency-names, 'no.nkk')
+          contains(steps.meta.outputs.dependency-names, 'no.nkk') ||
+          steps.meta.outputs.dependency-group != ''
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
# Pull Request

## Description

Extend auto-merge eligibility to grouped Dependabot PRs.

Currently, auto-merge only fires for semver-patch updates, GitHub Actions, and NKK-internal Maven dependencies. Grouped PRs (angular, typescript, testing, keycloak, tailwind, all, etc.) that include a semver-minor update are skipped — they sit open indefinitely.

Fix: add `steps.meta.outputs.dependency-group != ''` to the condition. If Dependabot placed the update in a named group, our `dependabot.yml` policy already controls what can enter that group (semver-major is blocked by the `ignore` rule), so any grouped PR is safe to auto-merge.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.


Fixes # (issue)


## How Has This Been Tested?

- [ ] I confirm that I have reproduced the initial situation
- [ ] I confirm that I have tested my implementation and it is working as expected

### Where was this tested?

- [ ] Localhost
- [ ] Inttest
- [ ] Prodtest
- [ ] Production

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules