### PR TITLE
chore: add reusable CodeQL workflow with Maven credentials

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: CodeQL Analysis
+
+on:
+  workflow_call:
+    secrets:
+      PACKAGES_TOKEN:
+        required: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: corretto
+          java-version: 21
+          overwrite-settings: false
+
+      - name: Configure Maven
+        run: |
+          mkdir -p ~/.m2
+          echo "<settings>
+                  <servers>
+                    <server><id>github</id><username>x-access-token</username><password>${{ secrets.GITHUB_TOKEN }}</password></server>
+                    <server><id>github-nkk-tng</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-ecvo</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-prove</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-helse</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-dommer</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-intouch</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-okonomi</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-utstilling</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-dyreidentitet</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-dyreidentitet-webservice-client</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-dyreidentitet-service</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-nkk-apache-tiles</id><username>x-access-token</username><password>${{ secrets.PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-origin-legacy</id><username>x-access-token</username><password>${{ secrets.ORIGIN_PACKAGES_TOKEN }}</password></server>
+                    <server><id>github-origin-gt-legacy</id><username>x-access-token</username><password>${{ secrets.ORIGIN_PACKAGES_TOKEN }}</password></server>
+                  </servers>
+                </settings>" > ~/.m2/settings.xml
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Reusable CodeQL workflow that configures `~/.m2/settings.xml` with `PACKAGES_TOKEN` before autobuild. Allows Java CodeQL analysis to resolve NKK-internal packages from GitHub Packages.