### PR TITLE
fix: add restore-keys fallback to Maven cache steps

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -63,6 +63,8 @@ jobs:
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Retrieve Axon license
       if: inputs.axon_license
       env:

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -60,6 +60,8 @@ jobs:
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Maven release
       run: |
         mvn --batch-mode versions:set -DnewVersion=${{ inputs.version }} -DprocessAllModules -DgenerateBackupPoms=false


### PR DESCRIPTION
# Pull Request

## Description

Without `restore-keys`, tag-triggered release builds fall back to the previous release-tag cache. That cache can contain stale negative resolution entries for GitHub Packages artifacts whose cross-repo routing has changed.

Concrete incident (2026-04-28, NKK-tng v26.4.4): `tiles-freemarker:4.0.0` stopped resolving from `github-nkk-dommer` between releases. The v26.4.3 release cache had a negative entry for `github-nkk-tng` for that JAR (it wasn't accessible there on April 23), so Maven skipped the one repo where it now works and the release failed.

Adding `restore-keys: ${{ runner.os }}-maven-` lets a release prefer the most recent build cache (e.g. from the just-merged PR) over an older release-tag cache, avoiding the stale-negative problem.

Changed in both `maven-build.yml` and `maven-release.yml`.

Fixes # (issue)

## How Has This Been Tested?

- [ ] I confirm that I have reproduced the initial situation
- [x] I confirm that I have tested my implementation and it is working as expected

The immediate fix (deleting the stale cache and rerunning the release) confirmed that a fresh cache resolves the artifact correctly. The `restore-keys` addition ensures future releases prefer fresh caches over stale ones.

### Where was this tested?

- [ ] Localhost
- [ ] Inttest
- [ ] Prodtest
- [ ] Production

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules