### PR TITLE
chore: utvid Dependabot auto-merge til semver-minor

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,8 @@ jobs:
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.package-ecosystem == 'github_actions' ||
           contains(steps.meta.outputs.dependency-names, 'no.nkk') ||
-          steps.meta.outputs.dependency-group != ''
+          steps.meta.outputs.dependency-group != '' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -33,7 +34,8 @@ jobs:
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.package-ecosystem == 'github_actions' ||
           contains(steps.meta.outputs.dependency-names, 'no.nkk') ||
-          steps.meta.outputs.dependency-group != ''
+          steps.meta.outputs.dependency-group != '' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
         run: gh pr checks "$PR_URL" --required --watch --fail-fast
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -44,7 +46,8 @@ jobs:
           steps.meta.outputs.update-type == 'version-update:semver-patch' ||
           steps.meta.outputs.package-ecosystem == 'github_actions' ||
           contains(steps.meta.outputs.dependency-names, 'no.nkk') ||
-          steps.meta.outputs.dependency-group != ''
+          steps.meta.outputs.dependency-group != '' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
         run: gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Beskrivelse

Utvider auto-merge til å omfatte `version-update:semver-minor`-oppdateringer.

I dag auto-merges kun semver-patch, GitHub Actions, NKK-interne avhengigheter og grupperte PR-er. Vanlige minor-bumper (npm) faller utenfor og blir liggende åpne i ukevis. Mens de venter, drifter `package-lock.json` ut av synk med `main`, og `npm ci` feiler med `EUSAGE` — så et voksende etterslep havner i en tilstand som krever manuell rebase.

Siden semver-major allerede er blokkert via `ignore`-regelen i `dependabot.yml`, og auto-merge uansett venter på at de påkrevde sjekkene passerer (`gh pr checks --required --watch --fail-fast`), er det trygt å la minor-oppdateringer auto-merges: alt som brekker bygget blir ikke merget.

Knyttet til opprydding av Dependabot-etterslep på tvers av repoene.