### PR TITLE
fiks: auto-merge tåler at påkrevde sjekker ikke er registrert ennå

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -36,7 +36,13 @@ jobs:
           contains(steps.meta.outputs.dependency-names, 'no.nkk') ||
           steps.meta.outputs.dependency-group != '' ||
           steps.meta.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr checks "$PR_URL" --required --watch --fail-fast
+        run: |
+          for i in $(seq 1 20); do
+            if gh pr checks "$PR_URL" --required --watch --fail-fast >/tmp/amchecks 2>&1; then exit 0; fi
+            grep -q "no required checks reported" /tmp/amchecks && { echo "Required checks not registered yet; waiting…"; sleep 15; continue; }
+            cat /tmp/amchecks; exit 1
+          done
+          echo "Timed out waiting for required checks to appear"; exit 1
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Beskrivelse

`Wait for required checks`-steget i auto-merge feilet i et race: når workflowen kjører på `synchronize`/rebase-eventet er ofte ikke `build`-sjekken registrert ennå, og `gh pr checks --required --watch --fail-fast` returnerer `no required checks reported` med exit 1. Da feilet hele auto-merge-jobben før bygget rakk å starte, og grønne, godkjente PR-er ble liggende umerget.

## Endring

Wait-steget prøver nå på nytt (inntil ~5 min) når påkrevde sjekker ennå ikke er rapportert, og venter deretter normalt på resultatet. Reelle sjekkfeil feiler fortsatt umiddelbart.

Knyttet til opprydding av Dependabot-etterslep.